### PR TITLE
`ShowMobileFooter` should not default to `true`.

### DIFF
--- a/app/src/main/java/ch/protonmail/android/api/models/User.java
+++ b/app/src/main/java/ch/protonmail/android/api/models/User.java
@@ -236,7 +236,7 @@ public class User {
         } else {
             user.mobileFooter = securePrefs.getString(PREF_MOBILE_FOOTER, ProtonMailApplication.getApplication().getString(R.string.default_mobile_footer));
         }
-        user.ShowMobileFooter = securePrefs.getBoolean(PREF_DISPLAY_MOBILE, true);
+        user.ShowMobileFooter = securePrefs.getBoolean(PREF_DISPLAY_MOBILE, false);
         if (!user.ShowMobileFooter && !user.isPaidUserSignatureEdit()) {
             user.ShowMobileFooter = true;
             user.setShowMobileFooter(true);


### PR DESCRIPTION
You guys probably aren't going to love this PR, but you disabled the issues page on the repo.

Clearly, paying users should not have---by default---ProtonMail EDITING their emails to include an advertisement for the service. This should be opt-in at best.  This kind of user-hostile behavior is truly bullshit.